### PR TITLE
Upgrade nuget packages to avoid conflicts with AWS apps

### DIFF
--- a/src/Albelli.Extensions.Configuration.AmazonEC2ParameterStore/Albelli.Extensions.Configuration.AmazonEC2ParameterStore.csproj
+++ b/src/Albelli.Extensions.Configuration.AmazonEC2ParameterStore/Albelli.Extensions.Configuration.AmazonEC2ParameterStore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Albelli.Extensions.Configuration.AmazonEC2ParameterStore</AssemblyName>
     <RootNamespace>Albelli.Extensions.Configuration.AmazonEC2ParameterStore</RootNamespace>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
@@ -21,12 +21,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.SimpleSystemsManagement" Version="3.5.9" />
+    <PackageReference Include="AWSSDK.SimpleSystemsManagement" Version="3.7.3.8" />
     <PackageReference Include="JetBrains.Annotations" Version="11.0.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.15" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.15" />
   </ItemGroup>
 
 </Project>

--- a/src/Albelli.Extensions.Configuration.AmazonEC2ParameterStore/AmazonEC2ParameterStoreProvider.cs
+++ b/src/Albelli.Extensions.Configuration.AmazonEC2ParameterStore/AmazonEC2ParameterStoreProvider.cs
@@ -72,7 +72,7 @@ namespace Albelli.Extensions.Configuration.AmazonEC2ParameterStore
 
         private async Task LoadAsync()
         {
-            foreach (var pair in await this.GetParametersAsync(this.client, this.rootPath))
+            foreach (var pair in await this.GetParametersAsync(this.client, this.rootPath).ConfigureAwait(false))
             {
                 this.Data.Add(pair.Key, pair.Value);
             }
@@ -92,7 +92,7 @@ namespace Albelli.Extensions.Configuration.AmazonEC2ParameterStore
 
             do
             {
-                var response = await ssm.GetParametersByPathAsync(request);
+                var response = await ssm.GetParametersByPathAsync(request).ConfigureAwait(false);
 
                 this.logger.LogInformation("EC2 ParameterStore has {ParametersCount} parameters in \'{ParametersPath}\'",
                     response.Parameters.Count,

--- a/src/Albelli.Extensions.Configuration.AmazonEC2ParameterStore/AmazonEC2ParameterStoreProviderExtensions.cs
+++ b/src/Albelli.Extensions.Configuration.AmazonEC2ParameterStore/AmazonEC2ParameterStoreProviderExtensions.cs
@@ -10,7 +10,7 @@ namespace Albelli.Extensions.Configuration.AmazonEC2ParameterStore
     public static class AmazonEC2ParameterStoreProviderExtensions
     {
         /// <summary>
-        /// Adds an <see cref="IConfigurationProvider"/> 
+        /// Adds an <see cref="IConfigurationProvider"/>
         /// that reads configuration values from AWS EC2 ParameterStore and decrypt them using AWS KMS.
         /// </summary>
         /// <param name="configurationBuilder">The <see cref="IConfigurationBuilder"/> to add to.</param>
@@ -41,7 +41,7 @@ namespace Albelli.Extensions.Configuration.AmazonEC2ParameterStore
         }
 
         /// <summary>
-        /// Adds an <see cref="IConfigurationProvider"/> 
+        /// Adds an <see cref="IConfigurationProvider"/>
         /// that reads configuration values from AWS EC2 ParameterStore and decrypt them using AWS KMS.
         /// </summary>
         /// <param name="configurationBuilder">The <see cref="IConfigurationBuilder"/> to add to.</param>
@@ -69,7 +69,7 @@ namespace Albelli.Extensions.Configuration.AmazonEC2ParameterStore
         }
 
         /// <summary>
-        /// Adds an <see cref="IConfigurationProvider"/> 
+        /// Adds an <see cref="IConfigurationProvider"/>
         /// that reads configuration values from AWS EC2 ParameterStore and decrypt them using AWS KMS.
         /// </summary>
         /// <param name="configurationBuilder">The <see cref="IConfigurationBuilder"/> to add to.</param>
@@ -98,7 +98,7 @@ namespace Albelli.Extensions.Configuration.AmazonEC2ParameterStore
         }
 
         /// <summary>
-        /// Adds an <see cref="IConfigurationProvider"/> 
+        /// Adds an <see cref="IConfigurationProvider"/>
         /// that reads configuration values from AWS EC2 ParameterStore and decrypt them using AWS KMS.
         /// </summary>
         /// <param name="configurationBuilder">The <see cref="IConfigurationBuilder"/> to add to.</param>
@@ -119,10 +119,10 @@ namespace Albelli.Extensions.Configuration.AmazonEC2ParameterStore
             bool parseStringListAsList = false)
         {
             return configurationBuilder.AddEC2ParameterStoreVariables(
-                rootPath, 
-                region, 
-                loggerFactory, 
-                credentials, 
+                rootPath,
+                region,
+                loggerFactory,
+                credentials,
                 parseStringListAsList);
         }
     }


### PR DESCRIPTION
Currently, if we want to update the package depended on AWS.Core we will have a dependency error because there is a restriction on the max version.

Proposed changes:
- Bump package versions

Unrelated changes:
- Remove trailing whitespaces
- Add `.ConfigureAwait(false)` to async calls. To avoid deadlocks it will be safer since its library code transforms to sync through the `.GetAwaiter().GetResult()` code.